### PR TITLE
Bump tox coverage to 3.9 to 3.11

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -15,6 +15,8 @@ jobs:
           - ubuntu-latest
         python-version:
           - 3.9
+          - 3.10
+          - 3.11
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -14,9 +14,9 @@ jobs:
         platform:
           - ubuntu-latest
         python-version:
-          - 3.9
-          - 3.10
-          - 3.11
+          - "3.9"
+          - "3.10"
+          - "3.11"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
https://www.home-assistant.io/blog/2023/03/01/release-20233/#python-311-support